### PR TITLE
Cc validation fixes

### DIFF
--- a/src/cc/CCinclude.h
+++ b/src/cc/CCinclude.h
@@ -923,8 +923,8 @@ bits256 bits256_doublesha256(char *deprecated,uint8_t *data,int32_t datalen);
 /*! \endcond */
 
 /*! \cond INTERNAL */
-int64_t TotalPubkeyNormalInputs(const CTransaction &tx, const CPubKey &pubkey);
-int64_t TotalPubkeyCCInputs(const CTransaction &tx, const CPubKey &pubkey);
+int64_t TotalPubkeyNormalInputs(const CTransaction &tx, const CPubKey &pubkey, Eval *eval);
+int64_t TotalPubkeyCCInputs(const CTransaction &tx, const CPubKey &pubkey, Eval *eval);
 inline std::string STR_TOLOWER(const std::string &str) { std::string out; for (std::string::const_iterator i = str.begin(); i != str.end(); i++) out += std::tolower(*i); return out; }
 /*! \endcond */
 

--- a/src/cc/CCtokens.cpp
+++ b/src/cc/CCtokens.cpp
@@ -472,7 +472,7 @@ int64_t IsTokensvout(bool goDeeper, bool checkPubkeys /*<--not used, always true
                             && !IsTokenMarkerVout(vout))  // should not be marker here
                             ccOutputs += vout.nValue;
 
-                    int64_t normalInputs = TotalPubkeyNormalInputs(tx, origPubkey);  // check if normal inputs are really signed by originator pubkey (someone not cheating with originator pubkey)
+                    int64_t normalInputs = TotalPubkeyNormalInputs(tx, origPubkey, eval);  // check if normal inputs are really signed by originator pubkey (someone not cheating with originator pubkey)
                     LOGSTREAM("cctokens", CCLOG_DEBUG2, stream << indentStr << "IsTokensvout() normalInputs=" << normalInputs << " ccOutputs=" << ccOutputs << " for tokenbase=" << reftokenid.GetHex() << std::endl);
 
                     if (normalInputs >= ccOutputs) {
@@ -828,7 +828,7 @@ std::string CreateToken(int64_t txfee, int64_t tokensupply, std::string name, st
 	if (AddNormalinputs2(mtx, tokensupply + 2 * txfee, 64) > 0)  // add normal inputs only from mypk
 	{
 
-        int64_t mypkInputs = TotalPubkeyNormalInputs(mtx, mypk);  
+        int64_t mypkInputs = TotalPubkeyNormalInputs(mtx, mypk, NULL);  
         if (mypkInputs < tokensupply) {     // check that tokens amount are really issued with mypk (because in the wallet there maybe other privkeys)
             CCerror = "some inputs signed not with -pubkey=pk";
             return std::string("");

--- a/src/cc/CCutilbits.cpp
+++ b/src/cc/CCutilbits.cpp
@@ -17,6 +17,7 @@
  CCutilbits.cpp has very low level functions that are universally useful for all contracts and have low dependency from other sources
  */
 
+#include "util.h"
 #include "CCinclude.h"
 
 int32_t unstringbits(char *buf,uint64_t bits)
@@ -99,17 +100,15 @@ CPubKey pubkey2pk(std::vector<uint8_t> vpubkey)
     return(pk);
 }
 
+// in powerblockcoin category is either ccinfo or ccdebug
 void CCLogPrintStr(const char *category, int level, const std::string &str)
 {
     if (level < 0)
         level = 0;
     if (level > CCLOG_MAXLEVEL)
         level = CCLOG_MAXLEVEL;
-//Accept any log category from cc
-//    for (int i = level; i <= CCLOG_MAXLEVEL; i++)
-//        if (LogAcceptCategory((std::string(category) + std::string("-") + std::to_string(i)).c_str()) ||     // '-debug=cctokens-0', '-debug=cctokens-1',...
-//            i == 0 && LogAcceptCategory(std::string(category).c_str())) {                                  // also supporting '-debug=cctokens' for CCLOG_INFO
-            LogPrintStr(str);
-//            break;
-//        }
+
+    if (LogAcceptCategory(BCLog::CCINFO) || level > 0 && LogAcceptCategory(BCLog::CCDEBUG)) {                                  
+        LogPrintStr(str);
+    }
 }

--- a/src/cc/CCutils.cpp
+++ b/src/cc/CCutils.cpp
@@ -728,13 +728,13 @@ CPubKey check_signing_pubkey(CScript scriptSig)
 
 
 // returns total of normal inputs signed with this pubkey
-int64_t TotalPubkeyNormalInputs(const CTransaction &tx, const CPubKey &pubkey)
+int64_t TotalPubkeyNormalInputs(const CTransaction &tx, const CPubKey &pubkey, Eval *eval)
 {
     int64_t total = 0;
     for (auto vin : tx.vin) {
         CTransaction vintx;
         uint256 hashBlock;
-        if (!IsCCInput(vin.scriptSig) && myGetTransaction(vin.prevout.hash, vintx, hashBlock)) {
+        if (!IsCCInput(vin.scriptSig) && myGetTransactionEval(eval, vin.prevout.hash, vintx, hashBlock)) {
             typedef std::vector<unsigned char> valtype;
             std::vector<valtype> vSolutions;
             txnouttype whichType;
@@ -757,7 +757,7 @@ int64_t TotalPubkeyNormalInputs(const CTransaction &tx, const CPubKey &pubkey)
 }
 
 // returns total of CC inputs signed with this pubkey
-int64_t TotalPubkeyCCInputs(const CTransaction &tx, const CPubKey &pubkey)
+int64_t TotalPubkeyCCInputs(const CTransaction &tx, const CPubKey &pubkey, Eval *eval)
 {
     int64_t total = 0;
     for (auto vin : tx.vin) {
@@ -767,7 +767,7 @@ int64_t TotalPubkeyCCInputs(const CTransaction &tx, const CPubKey &pubkey)
                 if (vinPubkey == pubkey) {
                     CTransaction vintx;
                     uint256 hashBlock;
-                    if (myGetTransaction(vin.prevout.hash, vintx, hashBlock)) {
+                    if (myGetTransactionEval(eval, vin.prevout.hash, vintx, hashBlock)) {
                         total += vintx.vout[vin.prevout.n].nValue;
                     }
                 }

--- a/src/cc/eval.cpp
+++ b/src/cc/eval.cpp
@@ -133,7 +133,6 @@ bool Eval::GetSpendsConfirmed(uint256 hash, std::vector<CTransaction> &spends) c
 
 bool Eval::GetTxUnconfirmed(const uint256 &hash, CTransaction &txOut, uint256 &hashBlock) const
 {
-    std::cerr << __func__ << " called for hash=" << hash.GetHex() << " blockTxns.get()=" << blockTxns.get() << " blockTxns.size()=" << (blockTxns != nullptr ? blockTxns->size() : 0) << std::endl;
     return(myGetTransactionBlockTxns(hash, txOut,hashBlock, blockTxns)); // call myGetTransaction that could look in block's txns instead of mempool, what is important in the cc validation at the block connection
     /*if (!myGetTransaction(hash, txOut,hashBlock)) {
         return(myGetTransaction(hash, txOut,hashBlock));

--- a/src/cc/eval.cpp
+++ b/src/cc/eval.cpp
@@ -128,6 +128,7 @@ bool Eval::GetSpendsConfirmed(uint256 hash, std::vector<CTransaction> &spends) c
 
 bool Eval::GetTxUnconfirmed(const uint256 &hash, CTransaction &txOut, uint256 &hashBlock) const
 {
+    std::cerr << __func__ << " called for hash=" << hash.GetHex() << " blockTxns.size()=" << blockTxns->size() << std::endl;
     return(myGetTransactionBlockTxns(hash, txOut,hashBlock, blockTxns)); // call myGetTransaction that could look in block's txns instead of mempool, what is important in the cc validation at the block connection
     /*if (!myGetTransaction(hash, txOut,hashBlock)) {
         return(myGetTransaction(hash, txOut,hashBlock));

--- a/src/cc/eval.cpp
+++ b/src/cc/eval.cpp
@@ -128,7 +128,7 @@ bool Eval::GetSpendsConfirmed(uint256 hash, std::vector<CTransaction> &spends) c
 
 bool Eval::GetTxUnconfirmed(const uint256 &hash, CTransaction &txOut, uint256 &hashBlock) const
 {
-    std::cerr << __func__ << " called for hash=" << hash.GetHex() << " blockTxns.size()=" << blockTxns->size() << std::endl;
+    std::cerr << __func__ << " called for hash=" << hash.GetHex() << " blockTxns.get()=" << blockTxns.get() << " blockTxns.size()=" << (blockTxns != nullptr ? blockTxns->size() : 0) << std::endl;
     return(myGetTransactionBlockTxns(hash, txOut,hashBlock, blockTxns)); // call myGetTransaction that could look in block's txns instead of mempool, what is important in the cc validation at the block connection
     /*if (!myGetTransaction(hash, txOut,hashBlock)) {
         return(myGetTransaction(hash, txOut,hashBlock));

--- a/src/cc/prices.cpp
+++ b/src/cc/prices.cpp
@@ -328,7 +328,7 @@ static bool ValidateBetTx(struct CCcontract_info *cp, Eval *eval, const CTransac
     for (auto vout : bettx.vout)
         if (vout.scriptPubKey.IsPayToCryptoCondition())  
             ccOutputs += vout.nValue;
-    CAmount normalInputs = TotalPubkeyNormalInputs(bettx, pk);
+    CAmount normalInputs = TotalPubkeyNormalInputs(bettx, pk, eval);
     if (normalInputs < ccOutputs) {
         return eval->Invalid("bettx normal inputs not signed with pubkey in opret");
     }

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -13,6 +13,7 @@
 #include <sync.h>
 #include <ui_interface.h>
 
+#include <deque>
 #include <memory>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -251,6 +251,8 @@ const CLogCategoryDesc LogCategories[] =
     {BCLog::QT, "qt"},
     {BCLog::LEVELDB, "leveldb"},
     {BCLog::NAMES, "names"},
+    {BCLog::CCINFO, "ccinfo"},
+    {BCLog::CCDEBUG, "ccdebug"},
     {BCLog::ALL, "1"},
     {BCLog::ALL, "all"},
 };

--- a/src/util.h
+++ b/src/util.h
@@ -106,6 +106,9 @@ namespace BCLog {
         QT          = (1 << 19),
         LEVELDB     = (1 << 20),
         NAMES       = (1 << 21),
+        CCINFO      = (1 << 22),
+        CCDEBUG     = (1 << 23),
+
         ALL         = ~(uint32_t)0,
     };
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1613,6 +1613,7 @@ bool CheckInputs(const CTransaction& tx, CValidationState &state, const CCoinsVi
                 // spent being checked as a part of CScriptCheck.
 
                 // Verify signature
+                std::cerr << __func__ << " _connectingBlockTxns=" << _connectingBlockTxns.get() << " _connectingBlockTxns->size()=" << (_connectingBlockTxns != nullptr ? _connectingBlockTxns->size() : 0) << std::endl;
                 CScriptCheck check(coin.out, tx, i, flags, cacheSigStore, &txdata, _connectingBlockTxns);
                 if (pvChecks) {
                     pvChecks->push_back(CScriptCheck());

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -54,8 +54,10 @@
 #include <boost/thread.hpp>
 #include <boost/foreach.hpp>
 
+#if !defined(BOOST_BIND_GLOBAL_PLACEHOLDERS)
 using boost::placeholders::_1;
 using boost::placeholders::_2;
+#endif
 
 #if defined(NDEBUG)
 # error "Bitcoin cannot be compiled without assertions."

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -54,9 +54,11 @@
 #include <boost/thread.hpp>
 #include <boost/foreach.hpp>
 
+#if BOOST_VERSION >= 107300
 #if !defined(BOOST_BIND_GLOBAL_PLACEHOLDERS)
 using boost::placeholders::_1;
 using boost::placeholders::_2;
+#endif
 #endif
 
 #if defined(NDEBUG)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5782,6 +5782,7 @@ bool myGetTransactionBlockTxns(const uint256 &hash, CTransaction &txOut, uint256
             // if a block is connecting then search in its txns instead of mempool
             // as mempool txns should not affect the txns from a connecting block
             auto foundit = blockTxns->find(hash);
+            std::cerr << __func__ << " search blockTxns for hash=" << hash.GetHex() << " foundit != blockTxns->end() is " << (foundit != blockTxns->end()) << std::endl;
             if (foundit != blockTxns->end())
             {
                 txOut = foundit->second;
@@ -5790,6 +5791,7 @@ bool myGetTransactionBlockTxns(const uint256 &hash, CTransaction &txOut, uint256
         }
         else
         {
+            std::cerr << __func__ << " search mempool for hash=" << hash.GetHex() << std::endl;
             //LogPrintf("check mempool %s\n",hash.GetHex().c_str());
             if (mempool.lookup(hash, txOut))
             {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5769,6 +5769,15 @@ int32_t powerblockcoin_priceget(int64_t *buf64,int32_t ind,int32_t height,int32_
     return(retval);
 }
 
+// for convenience, calls eval's get transaction version if eval is set
+bool myGetTransactionEval(Eval *eval, const uint256 &hash, CTransaction &txOut, uint256 &hashBlock)
+{
+    if (eval)
+        return eval->GetTxUnconfirmed(hash, txOut, hashBlock);
+    else
+        return myGetTransaction(hash, txOut, hashBlock);
+}
+
 // Extra GetTransaction version that looks into current block txns or in mempool
 // for use in cc validation code
 bool myGetTransactionBlockTxns(const uint256 &hash, CTransaction &txOut, uint256 &hashBlock, BlockTxnsPtr blockTxns)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1613,7 +1613,6 @@ bool CheckInputs(const CTransaction& tx, CValidationState &state, const CCoinsVi
                 // spent being checked as a part of CScriptCheck.
 
                 // Verify signature
-                std::cerr << __func__ << " _connectingBlockTxns=" << _connectingBlockTxns.get() << " _connectingBlockTxns->size()=" << (_connectingBlockTxns != nullptr ? _connectingBlockTxns->size() : 0) << std::endl;
                 CScriptCheck check(coin.out, tx, i, flags, cacheSigStore, &txdata, _connectingBlockTxns);
                 if (pvChecks) {
                     pvChecks->push_back(CScriptCheck());
@@ -5792,7 +5791,6 @@ bool myGetTransactionBlockTxns(const uint256 &hash, CTransaction &txOut, uint256
             // if a block is connecting then search in its txns instead of mempool
             // as mempool txns should not affect the txns from a connecting block
             auto foundit = blockTxns->find(hash);
-            std::cerr << __func__ << " search blockTxns for hash=" << hash.GetHex() << " foundit != blockTxns->end() is " << (foundit != blockTxns->end()) << std::endl;
             if (foundit != blockTxns->end())
             {
                 txOut = foundit->second;
@@ -5801,7 +5799,6 @@ bool myGetTransactionBlockTxns(const uint256 &hash, CTransaction &txOut, uint256
         }
         else
         {
-            std::cerr << __func__ << " search mempool for hash=" << hash.GetHex() << std::endl;
             //LogPrintf("check mempool %s\n",hash.GetHex().c_str());
             if (mempool.lookup(hash, txOut))
             {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -54,6 +54,9 @@
 #include <boost/thread.hpp>
 #include <boost/foreach.hpp>
 
+using boost::placeholders::_1;
+using boost::placeholders::_2;
+
 #if defined(NDEBUG)
 # error "Bitcoin cannot be compiled without assertions."
 #endif

--- a/src/validation.h
+++ b/src/validation.h
@@ -23,6 +23,7 @@
 #include <versionbits.h>
 #include <spentindex.h>
 #include <txmempool.h>
+#include "cc/eval.h"
 
 #include <algorithm>
 #include <exception>
@@ -891,6 +892,7 @@ int64_t powerblockcoin_priceave(int64_t *buf,int64_t *correlated,int32_t cskip);
 int32_t powerblockcoin_priceget(int64_t *buf64,int32_t ind,int32_t height,int32_t numblocks);
 bool myGetTransaction(const uint256 &hash, CTransaction &txOut, uint256 &hashBlock);
 bool myGetTransactionBlockTxns(const uint256 &hash, CTransaction &txOut, uint256 &hashBlock, BlockTxnsPtr blockTxns);
+bool myGetTransactionEval(Eval *eval, const uint256 &hash, CTransaction &txOut, uint256 &hashBlock);
 
 uint64_t powerblockcoin_block_prg(uint32_t nHeight);
 int32_t iguana_rwnum(int32_t rwflag,uint8_t *serialized,int32_t len,void *endianedp);

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -20,10 +20,12 @@
 
 #include <boost/signals2/signal.hpp>
 
+#if BOOST_VERSION >= 107300
 #if !defined(BOOST_BIND_GLOBAL_PLACEHOLDERS)
 using boost::placeholders::_1;
 using boost::placeholders::_2;
 using boost::placeholders::_3;
+#endif
 #endif
 
 struct MainSignalsInstance {

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -20,6 +20,10 @@
 
 #include <boost/signals2/signal.hpp>
 
+using boost::placeholders::_1;
+using boost::placeholders::_2;
+using boost::placeholders::_3;
+
 struct MainSignalsInstance {
     boost::signals2::signal<void (const CBlockIndex *, const CBlockIndex *, bool fInitialDownload)> UpdatedBlockTip;
     boost::signals2::signal<void (const CTransactionRef &)> TransactionAddedToMempool;

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -20,9 +20,11 @@
 
 #include <boost/signals2/signal.hpp>
 
+#if !defined(BOOST_BIND_GLOBAL_PLACEHOLDERS)
 using boost::placeholders::_1;
 using boost::placeholders::_2;
 using boost::placeholders::_3;
+#endif
 
 struct MainSignalsInstance {
     boost::signals2::signal<void (const CBlockIndex *, const CBlockIndex *, bool fInitialDownload)> UpdatedBlockTip;


### PR DESCRIPTION
fixed blockTxnPtr init in eval object;
added eval param to function used inside validation;
removed a mempool call inside validation causing deadlock;
added cc log category